### PR TITLE
Update Ruby version so that vim upgrade from `vim 7.4` to `vim 8.0`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.0
+FROM ruby:2.3.8
 
 MAINTAINER kramos
 


### PR DESCRIPTION
Update Ruby version so that vim upgrade from `vim 7.4` to `vim 8.0`.